### PR TITLE
Add advanced JSON form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ This project includes a Cloudflare Worker that schedules messages to be sent to 
    ```
 
 The worker exposes a simple HTML form at the root path. Fill in the group ID, sender ID, message content and the ISO timestamp for when the message should be sent. The form submission stores the request in KV. A scheduled event runs every minute to check for pending messages and sends them to `https://propaganda-production.up.railway.app/api/send/`.
+
+For advanced usage, navigate to `/advanced` which exposes a large textarea pre-filled with a JSON template. Modify the JSON as needed and submit the form to immediately POST the payload to the same API endpoint.


### PR DESCRIPTION
## Summary
- allow posting arbitrary JSON messages via `/advanced`
- show template payload for convenience
- document advanced endpoint
- add `.gitignore`

## Testing
- `npx tsc`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684152aa0b708332b283c6bacc7c9f8e