### PR TITLE
Enhance advanced scheduling UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ shows the JSON payload that can be posted to a backend of your choice.
 
 The worker exposes a simple HTML form at the root path. Fill in the group ID, sender ID, message content and the ISO timestamp for when the message should be sent. The form submission stores the request in KV. A scheduled event runs every minute to check for pending messages and sends them to `https://propaganda-production.up.railway.app/api/send/`.
 
-For advanced usage, navigate to `/advanced` which exposes a large textarea pre-filled with a JSON template. Modify the JSON as needed and submit the form to immediately POST the payload to the same API endpoint.
+For advanced usage, navigate to `/advanced`. This page lets you build a JSON payload using a dynamic form where you can add multiple groups, conversations and messages with individual `send_at` timestamps. Submitting the form stores the messages in KV. The cron job later reads the stored tasks and dispatches them to the API when the scheduled time arrives.

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,17 @@ interface SchedulePayload {
   // Unix timestamp (milliseconds) when the message should be sent
   send_at: number
 }
+interface AdvancedMessageTask {
+  group_id: string
+  conversation_id?: string
+  message: {
+    sender_id: string
+    message_content: string
+    reply_to?: string
+  }
+  send_at: number
+}
+
 
 // Endpoint that ultimately receives the scheduled messages
 const API_URL = 'https://propaganda-production.up.railway.app/api/send/'
@@ -57,7 +68,17 @@ const DEFAULT_JSON = `{
       "created_by": 123456789,
       "group_description": "Daily chat about BTC, ETH, and alt-coins.",
       "members": [],
-      "conversations": []
+      "conversations": [
+        {
+          "messages": [
+            {
+              "sender_id": "123456789",
+              "message_content": "Hello world",
+              "send_at": "2025-06-05T13:00:00Z"
+            }
+          ]
+        }
+      ]
     }
   ],
   "ai_users": [],
@@ -128,32 +149,158 @@ app.get('/advanced', c => {
   const html = `<!DOCTYPE html>
   <html>
   <body>
-    <h1>Send Custom JSON</h1>
-    <form method="POST" action="/advanced">
-      <textarea name="payload" rows="30" cols="80">${DEFAULT_JSON}</textarea><br/>
+    <h1>Advanced Scheduler</h1>
+    <h2>System Metadata</h2>
+    <label>Version <input id="sys-version"/></label><br/>
+    <label>Generated At <input id="sys-generated-at" placeholder="2025-06-05T01:45:00Z"/></label><br/>
+    <label>Timezone <input id="sys-timezone" value="UTC"/></label><br/>
+    <label>Description <input id="sys-description"/></label>
+
+    <h2>Groups</h2>
+    <div id="groups"></div>
+    <button type="button" id="addGroup">Add Group</button>
+
+    <form method="POST" action="/advanced" style="margin-top:20px;">
+      <input type="hidden" name="payload" id="payload" />
       <button type="submit">Send</button>
     </form>
+
+    <pre id="preview"></pre>
+
+    <script>
+      const groupsEl = document.getElementById('groups');
+      document.getElementById('addGroup').onclick = () => addGroup();
+
+      function addGroup() {
+        const g = document.createElement('div');
+        g.className = 'group';
+        g.innerHTML = \`
+          <hr/>
+          <label>Group ID <input class="group-id"/></label>
+          <label>Group Name <input class="group-name"/></label><br/>
+          <div class="conversations"></div>
+          <button type="button" class="add-conv">Add Conversation</button>
+        \`;
+        groupsEl.appendChild(g);
+        g.querySelector('.add-conv').onclick = () => addConversation(g);
+      }
+
+      function addConversation(groupDiv) {
+        const c = document.createElement('div');
+        c.className = 'conversation';
+        c.innerHTML = \`
+          <h4>Conversation</h4>
+          <label>Conversation ID <input class="conversation-id"/></label><br/>
+          <div class="messages"></div>
+          <button type="button" class="add-msg">Add Message</button>
+        \`;
+        groupDiv.querySelector('.conversations').appendChild(c);
+        c.querySelector('.add-msg').onclick = () => addMessage(c);
+      }
+
+      function addMessage(convDiv) {
+        const m = document.createElement('div');
+        m.className = 'message';
+        m.innerHTML = \`
+          <label>Sender ID <input class="sender-id"/></label>
+          <label>Content <input class="message-content"/></label>
+          <label>Send At <input class="send-at" placeholder="2025-06-05T13:00:00Z"/></label>
+          <label>Reply To <input class="reply-to"/></label><br/>
+        \`;
+        convDiv.querySelector('.messages').appendChild(m);
+      }
+
+      // Start with one group for convenience
+      addGroup();
+
+      document.querySelector('form').onsubmit = () => {
+        const payload = {
+          system_metadata: {
+            version: document.getElementById('sys-version').value,
+            generated_at: document.getElementById('sys-generated-at').value,
+            timezone: document.getElementById('sys-timezone').value,
+            description: document.getElementById('sys-description').value
+          },
+          groups: []
+        };
+
+        document.querySelectorAll('.group').forEach(g => {
+          const group = {
+            group_id: g.querySelector('.group-id').value,
+            group_name: g.querySelector('.group-name').value,
+            conversations: []
+          };
+          g.querySelectorAll('.conversation').forEach(c => {
+            const conv = {
+              conversation_id: c.querySelector('.conversation-id').value,
+              messages: []
+            };
+            c.querySelectorAll('.message').forEach(m => {
+              conv.messages.push({
+                sender_id: m.querySelector('.sender-id').value,
+                message_content: m.querySelector('.message-content').value,
+                send_at: m.querySelector('.send-at').value,
+                reply_to: m.querySelector('.reply-to').value
+              });
+            });
+            group.conversations.push(conv);
+          });
+          payload.groups.push(group);
+        });
+
+        const json = JSON.stringify(payload);
+        document.getElementById('payload').value = json;
+        document.getElementById('preview').textContent = JSON.stringify(payload, null, 2);
+      };
+    </script>
   </body>
   </html>`
   return c.html(html)
 })
 
-// Accept the JSON entered on the advanced form and relay it to the API
+// Accept the JSON entered on the advanced form and store each message as a task
 app.post('/advanced', async c => {
   const body = await c.req.parseBody()
-  const payload = body["payload"]?.toString() || ''
-  if (!payload) return c.json({ error: 'Missing payload' }, 400)
+  const payloadStr = body["payload"]?.toString() || ''
+  if (!payloadStr) return c.json({ error: 'Missing payload' }, 400)
+  let payload: any
   try {
-    JSON.parse(payload)
+    payload = JSON.parse(payloadStr)
   } catch {
     return c.json({ error: 'Invalid JSON' }, 400)
   }
-  await fetch(API_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: payload
-  })
-  return c.json({ status: 'sent' })
+
+  if (!Array.isArray(payload.groups)) {
+    return c.json({ error: 'Payload missing groups array' }, 400)
+  }
+
+  const ids: string[] = []
+  for (const group of payload.groups) {
+    if (!group.group_id || !Array.isArray(group.conversations)) continue
+    for (const conv of group.conversations) {
+      const convId = conv.conversation_id || crypto.randomUUID()
+      if (!Array.isArray(conv.messages)) continue
+      for (const msg of conv.messages) {
+        const ts = Date.parse(msg.send_at || msg.timestamp || '')
+        if (!msg.sender_id || !msg.message_content || isNaN(ts)) continue
+        const task: AdvancedMessageTask = {
+          group_id: group.group_id,
+          conversation_id: convId,
+          message: {
+            sender_id: msg.sender_id,
+            message_content: msg.message_content,
+            reply_to: msg.reply_to
+          },
+          send_at: ts
+        }
+        const id = crypto.randomUUID()
+        await c.env.SCHEDULE_KV.put(`task:${id}`, JSON.stringify(task))
+        ids.push(id)
+      }
+    }
+  }
+
+  return c.json({ status: 'scheduled', ids })
 })
 
 // Export the app to let Wrangler handle requests
@@ -166,19 +313,37 @@ export const scheduled = async (event: ScheduledController, env: Env, ctx: Execu
 
   const list = await env.SCHEDULE_KV.list({ prefix: 'task:' })
   for (const key of list.keys) {
-    const task = await env.SCHEDULE_KV.get(key.name, { type: 'json' }) as SchedulePayload | null
-    if (!task) continue
-    // Send tasks whose time has arrived
+    const data = await env.SCHEDULE_KV.get(key.name, { type: 'json' }) as any
+    if (!data) continue
 
-    if (task.send_at <= now) {
+    const send = async (groups: any) => {
       await fetch(API_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ groups: task.groups })
+        body: JSON.stringify({ groups })
       })
-      // Remove the task once sent
-
       await env.SCHEDULE_KV.delete(key.name)
+    }
+
+    if ('groups' in data) {
+      const task = data as SchedulePayload
+      if (task.send_at <= now) {
+        await send(task.groups)
+      }
+    } else if ('group_id' in data && 'message' in data) {
+      const task = data as AdvancedMessageTask
+      if (task.send_at <= now) {
+        await send([
+          {
+            group_id: task.group_id,
+            conversations: [
+              {
+                messages: [task.message]
+              }
+            ]
+          }
+        ])
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- overhaul the `/advanced` page with a dynamic form for multiple groups and conversations
- update README to describe the new advanced workflow

## Testing
- `npm install`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_684163e843f0833285e6887415a4e49f