### PR TITLE
Add wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ shows the JSON payload that can be posted to a backend of your choice.
 The worker exposes a simple HTML form at the root path. Fill in the group ID, sender ID, message content and the ISO timestamp for when the message should be sent. The form submission stores the request in KV. A scheduled event runs every minute to check for pending messages and sends them to `https://propaganda-production.up.railway.app/api/send/`.
 
 For advanced usage, navigate to `/advanced`. This page lets you build a JSON payload using a dynamic form where you can add multiple groups, conversations and messages with individual `send_at` timestamps. Submitting the form stores the messages in KV. The cron job later reads the stored tasks and dispatches them to the API when the scheduled time arrives.
+
+For a guided setup experience, visit `/wizard`. This multi-step form walks through each field and posts the assembled JSON to `/advanced` when finished.

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const DEFAULT_JSON = `{
     "version": "1.0.1",
     "generated_at": "2025-06-05T01:45:00Z",
     "timezone": "UTC",
-    "description": "Ledger of AI-only outbound interactions inside Telegram groups"
+    "description": "Sample with two groups, two conversations and three AI users"
   },
   "groups": [
     {
@@ -70,20 +70,205 @@ const DEFAULT_JSON = `{
       "members": [],
       "conversations": [
         {
+          "conversation_id": "conv1",
           "messages": [
             {
-              "sender_id": "123456789",
-              "message_content": "Hello world",
+              "sender_id": "987654321",
+              "message_content": "Welcome to Crypto Talk!",
               "send_at": "2025-06-05T13:00:00Z"
+            },
+            {
+              "sender_id": "876543210",
+              "message_content": "Glad to be here.",
+              "send_at": "2025-06-05T13:05:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "group_id": "-1001234567890",
+      "group_name": "Altcoin Updates",
+      "privacy_level": "public",
+      "created_at": "2024-12-02T12:00:00Z",
+      "created_by": 987654321,
+      "group_description": "News about altcoins.",
+      "members": [],
+      "conversations": [
+        {
+          "conversation_id": "conv2",
+          "messages": [
+            {
+              "sender_id": "765432109",
+              "message_content": "Daily altcoin update",
+              "send_at": "2025-06-06T09:00:00Z"
             }
           ]
         }
       ]
     }
   ],
-  "ai_users": [],
+  "ai_users": [
+    { "user_id": "987654321", "user_name": "CryptoBot", "role": "assistant", "status": "active" },
+    { "user_id": "876543210", "user_name": "MarketBot", "role": "assistant", "status": "active" },
+    { "user_id": "765432109", "user_name": "NewsBot", "role": "assistant", "status": "active" }
+  ],
   "audit_log": []
 }`
+
+const WIZARD_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Setup Wizard</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+  <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@mui/material@5/umd/material-ui.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>body { margin: 0; padding: 20px; font-family: Roboto, sans-serif; }</style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const { Stepper, Step, StepLabel, Button, TextField, Container, Box } = MaterialUI;
+
+    function App() {
+      const steps = ['System Metadata', 'Group Info', 'Conversation', 'Message', 'AI User', 'Audit Log', 'Summary'];
+      const [activeStep, setActiveStep] = React.useState(0);
+      const [data, setData] = React.useState({
+        system_metadata: { version: '', generated_at: '', timezone: '', description: '' },
+        group: { group_id: '', group_name: '', privacy_level: '', created_at: '', created_by: '', group_description: '' },
+        conversation: { conversation_id: '', start_time: '', initiated_by: '', topic: '' },
+        message: { message_id: '', sender_id: '', message_content: '', timestamp: '' },
+        ai_user: { user_id: '', user_name: '', role: '', status: '', max_messages_per_hour: '' },
+        audit_log: { event_id: '', event_type: '', actor_id: '', target_id: '', timestamp: '' }
+      });
+
+      const handleChange = (path) => (e) => {
+        const keys = path.split('.');
+        setData(prev => {
+          const updated = { ...prev };
+          let obj = updated;
+          for (let i = 0; i < keys.length - 1; i++) obj = obj[keys[i]];
+          obj[keys[keys.length - 1]] = e.target.value;
+          return updated;
+        });
+      };
+
+      const handleNext = () => setActiveStep(s => s + 1);
+      const handleBack = () => setActiveStep(s => s - 1);
+
+      const renderSystem = () => (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 4 }}>
+          <TextField label="Version" value={data.system_metadata.version} onChange={handleChange('system_metadata.version')} />
+          <TextField label="Generated At" placeholder="2025-06-05T01:45:00Z" value={data.system_metadata.generated_at} onChange={handleChange('system_metadata.generated_at')} />
+          <TextField label="Timezone" value={data.system_metadata.timezone} onChange={handleChange('system_metadata.timezone')} />
+          <TextField label="Description" value={data.system_metadata.description} onChange={handleChange('system_metadata.description')} />
+        </Box>
+      );
+
+      const renderGroup = () => (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 4 }}>
+          <TextField label="Group ID" value={data.group.group_id} onChange={handleChange('group.group_id')} />
+          <TextField label="Group Name" value={data.group.group_name} onChange={handleChange('group.group_name')} />
+          <TextField label="Privacy Level" value={data.group.privacy_level} onChange={handleChange('group.privacy_level')} />
+          <TextField label="Created At" placeholder="2024-12-01T18:09:55Z" value={data.group.created_at} onChange={handleChange('group.created_at')} />
+          <TextField label="Created By" value={data.group.created_by} onChange={handleChange('group.created_by')} />
+          <TextField label="Group Description" value={data.group.group_description} onChange={handleChange('group.group_description')} />
+        </Box>
+      );
+
+      const renderConversation = () => (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 4 }}>
+          <TextField label="Conversation ID" value={data.conversation.conversation_id} onChange={handleChange('conversation.conversation_id')} />
+          <TextField label="Start Time" placeholder="2025-06-04T22:17:12Z" value={data.conversation.start_time} onChange={handleChange('conversation.start_time')} />
+          <TextField label="Initiated By" value={data.conversation.initiated_by} onChange={handleChange('conversation.initiated_by')} />
+          <TextField label="Topic" value={data.conversation.topic} onChange={handleChange('conversation.topic')} />
+        </Box>
+      );
+
+      const renderMessage = () => (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 4 }}>
+          <TextField label="Message ID" value={data.message.message_id} onChange={handleChange('message.message_id')} />
+          <TextField label="Sender ID" value={data.message.sender_id} onChange={handleChange('message.sender_id')} />
+          <TextField label="Content" value={data.message.message_content} onChange={handleChange('message.message_content')} />
+          <TextField label="Timestamp" placeholder="2025-06-04T22:20:00Z" value={data.message.timestamp} onChange={handleChange('message.timestamp')} />
+        </Box>
+      );
+
+      const renderAIUser = () => (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 4 }}>
+          <TextField label="User ID" value={data.ai_user.user_id} onChange={handleChange('ai_user.user_id')} />
+          <TextField label="User Name" value={data.ai_user.user_name} onChange={handleChange('ai_user.user_name')} />
+          <TextField label="Role" value={data.ai_user.role} onChange={handleChange('ai_user.role')} />
+          <TextField label="Status" value={data.ai_user.status} onChange={handleChange('ai_user.status')} />
+          <TextField label="Max Msgs/Hour" value={data.ai_user.max_messages_per_hour} onChange={handleChange('ai_user.max_messages_per_hour')} />
+        </Box>
+      );
+
+      const renderAudit = () => (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 4 }}>
+          <TextField label="Event ID" value={data.audit_log.event_id} onChange={handleChange('audit_log.event_id')} />
+          <TextField label="Event Type" value={data.audit_log.event_type} onChange={handleChange('audit_log.event_type')} />
+          <TextField label="Actor ID" value={data.audit_log.actor_id} onChange={handleChange('audit_log.actor_id')} />
+          <TextField label="Target ID" value={data.audit_log.target_id} onChange={handleChange('audit_log.target_id')} />
+          <TextField label="Timestamp" placeholder="2025-06-04T22:16:54Z" value={data.audit_log.timestamp} onChange={handleChange('audit_log.timestamp')} />
+        </Box>
+      );
+
+      const renderSummary = () => (
+        <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginTop: 16 }}>
+{JSON.stringify(data, null, 2)}
+        </pre>
+      );
+
+      const renderStepContent = (step) => {
+        switch (step) {
+          case 0: return renderSystem();
+          case 1: return renderGroup();
+          case 2: return renderConversation();
+          case 3: return renderMessage();
+          case 4: return renderAIUser();
+          case 5: return renderAudit();
+          default: return renderSummary();
+        }
+      };
+
+      const submit = async () => {
+        const resp = await fetch('/advanced', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ payload: JSON.stringify(data) })
+        });
+        const result = await resp.json();
+        alert('Server response: ' + JSON.stringify(result));
+      };
+
+      return (
+        <Container maxWidth="sm">
+          <Stepper activeStep={activeStep} sx={{ mt: 2 }}>
+            {steps.map(label => (
+              <Step key={label}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            ))}
+          </Stepper>
+          {renderStepContent(activeStep)}
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 4 }}>
+            {activeStep > 0 && <Button onClick={handleBack}>Back</Button>}
+            {activeStep < steps.length - 1 && <Button variant="contained" onClick={handleNext}>Next</Button>}
+            {activeStep === steps.length - 1 && <Button variant="contained" onClick={submit}>Send</Button>}
+          </Box>
+        </Container>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>`
 
 app.get('/', c => {
   // Simple form UI to schedule a message
@@ -102,6 +287,11 @@ app.get('/', c => {
   </body>
   </html>`
   return c.html(html)
+})
+
+// Multi-step wizard that posts JSON to /advanced
+app.get('/wizard', c => {
+  return c.html(WIZARD_HTML)
 })
 
 app.post('/schedule', async c => {
@@ -168,7 +358,9 @@ app.get('/advanced', c => {
     <pre id="preview"></pre>
 
     <script>
+      const DEFAULT_JSON = ${JSON.stringify(DEFAULT_JSON)};
       const groupsEl = document.getElementById('groups');
+      document.getElementById('preview').textContent = DEFAULT_JSON;
       document.getElementById('addGroup').onclick = () => addGroup();
 
       function addGroup() {


### PR DESCRIPTION
## Summary
- add a multi‑step setup wizard served at `/wizard`
- document the new wizard in the README

## Testing
- `npx tsc` *(fails: Cannot find type definition file for '@cloudflare/workers-types')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68417d5e9ee883328d31074efc62d62b