### PR TITLE
Add Telegram-style multi group chat page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ For a guided setup experience, visit `/wizard`. This multi-step form walks throu
 ### Telegram-style Scheduler
 
 Navigate to `/chat` for a Telegram-style interface powered by **react-chat-elements**. Enter a group ID and sender name, type your message and optionally pick a time. Messages appear in a scrolling chat window and can be scheduled in bulk with **Schedule All** which posts them to `/advanced`.
+
+Visit `/chatpage` for a multi-group view showing several chats at once. The page lists your groups using **ChatItem** components from **react-chat-elements**. Select a group to see its message history and send new messages.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { Env } from './types'
 import registerRoot from './routes/root'
 import registerWizard from './routes/wizard'
 import registerChat from './routes/chat'
+import registerChatPage from './routes/chatpage'
 import registerSchedule from './routes/schedule'
 import registerAdvanced from './routes/advanced'
 import registerLog from './routes/log'
@@ -14,6 +15,7 @@ const app = new Hono<{ Bindings: Env }>()
 registerRoot(app)
 registerWizard(app)
 registerChat(app)
+registerChatPage(app)
 registerSchedule(app)
 registerAdvanced(app)
 registerLog(app)

--- a/src/routes/chatpage.ts
+++ b/src/routes/chatpage.ts
@@ -1,0 +1,94 @@
+import { Hono } from 'hono'
+import type { Env } from '../types'
+
+const HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Chat Page</title>
+  <link rel="stylesheet" href="https://unpkg.com/react-chat-elements/dist/main.css" />
+  <script type="module">
+    import React from 'https://esm.sh/react@18.2.0'
+    import ReactDOM from 'https://esm.sh/react-dom@18.2.0'
+    import { ChatList, MessageList, Input } from 'https://esm.sh/react-chat-elements@12.0.18'
+    window.React = React
+    window.ReactDOM = ReactDOM
+    window.ReactChatElements = { ChatList, MessageList, Input }
+  </script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    body { margin: 0; font-family: Arial, sans-serif; }
+    .container { display: flex; max-width: 800px; height: 500px; margin: 20px auto; border: 1px solid #ccc; }
+    .sidebar { width: 250px; border-right: 1px solid #ccc; overflow-y: auto; }
+    .chat { flex: 1; display: flex; flex-direction: column; }
+    .chat-body { flex: 1; overflow-y: auto; padding: 10px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const { ChatList, MessageList, Input } = window.ReactChatElements;
+
+    function App() {
+      const [groups, setGroups] = React.useState([]);
+      const [active, setActive] = React.useState(null);
+      const [groupName, setGroupName] = React.useState('');
+      const [text, setText] = React.useState('');
+
+      const addGroup = () => {
+        if (!groupName) return;
+        const g = { id: Date.now().toString(), name: groupName, messages: [] };
+        setGroups(prev => [...prev, g]);
+        setActive(g);
+        setGroupName('');
+      };
+
+      const addMessage = () => {
+        if (!active || !text) return;
+        const msg = { position: 'right', type: 'text', text, date: new Date() };
+        setGroups(prev => prev.map(g => g.id === active.id ? { ...g, messages: [...g.messages, msg] } : g));
+        setText('');
+      };
+
+      const chatItems = groups.map(g => ({
+        id: g.id,
+        title: g.name,
+        subtitle: g.messages[g.messages.length - 1]?.text || '',
+        date: g.messages[g.messages.length - 1]?.date
+      }));
+
+      const activeMessages = active ? active.messages : [];
+
+      return (
+        <div className="container">
+          <div className="sidebar">
+            <div style={{ padding: 10 }}>
+              <input placeholder="New group" value={groupName} onChange={e => setGroupName(e.target.value)} />
+              <button onClick={addGroup}>Add</button>
+            </div>
+            <ChatList className="chat-list" dataSource={chatItems} onClick={item => setActive(groups.find(g => g.id === item.id))} />
+          </div>
+          <div className="chat">
+            <div className="chat-body">
+              <MessageList className="message-list" lockable={true} toBottomHeight={'100%'} dataSource={activeMessages} />
+            </div>
+            <Input
+              placeholder="Message"
+              multiline={true}
+              value={text}
+              onChange={e => setText(e.target.value)}
+              rightButtons={<button onClick={addMessage}>Send</button>}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>`
+
+export default function register(app: Hono<{ Bindings: Env }>) {
+  app.get('/chatpage', c => c.html(HTML))
+}


### PR DESCRIPTION
## Summary
- add `/chatpage` route using `react-chat-elements`
- register the new route in the worker
- document the new chat page in README

## Testing
- `npm install`
- `npx tsc`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841b1bc3cdc8332874c1d2c8150dac8