### PR TITLE
Add Telegram-style chat list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ For a guided setup experience, visit `/wizard`. This multi-step form walks throu
 ### Telegram-style Scheduler
 
 Navigate to `/chat` for a Telegram-style interface powered by **react-chat-elements**. Enter a group ID and sender name, type your message and optionally pick a time. Messages appear in a scrolling chat window and can be scheduled in bulk with **Schedule All** which posts them to `/advanced`.
+
+Visit `/chatpage` for a multi-group view rendered with **ChatList** from **react-chat-elements**. The page lists a few sample chats similar to Telegram.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { Env } from './types'
 import registerRoot from './routes/root'
 import registerWizard from './routes/wizard'
 import registerChat from './routes/chat'
+import registerChatPage from './routes/chatpage'
 import registerSchedule from './routes/schedule'
 import registerAdvanced from './routes/advanced'
 import registerLog from './routes/log'
@@ -14,6 +15,7 @@ const app = new Hono<{ Bindings: Env }>()
 registerRoot(app)
 registerWizard(app)
 registerChat(app)
+registerChatPage(app)
 registerSchedule(app)
 registerAdvanced(app)
 registerLog(app)

--- a/src/routes/chatpage.ts
+++ b/src/routes/chatpage.ts
@@ -1,0 +1,46 @@
+import { Hono } from 'hono'
+import type { Env } from '../types'
+
+const HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Chat Page</title>
+  <link rel="stylesheet" href="https://unpkg.com/react-chat-elements/dist/main.css" />
+  <script type="module">
+    import React from 'https://esm.sh/react@18.2.0'
+    import { createRoot } from 'https://esm.sh/react-dom@18.2.0/client'
+    import { ChatList } from 'https://esm.sh/react-chat-elements@12.0.18'
+    const root = createRoot(document.getElementById('root'))
+    const chats = [
+      {
+        avatar: 'https://avatars.githubusercontent.com/u/80540635?v=4',
+        alt: 'kursat_avatar',
+        title: 'Kursat',
+        subtitle: "Why don't we go to the No Way Home movie this weekend ?",
+        date: new Date(),
+        unread: 3,
+      },
+      {
+        avatar: 'https://avatars.githubusercontent.com/u/80540635?v=4',
+        alt: 'kursat_avatar',
+        title: 'Group 2',
+        subtitle: 'Another recent message snippet...',
+        date: new Date(),
+        unread: 1,
+      }
+    ]
+    root.render(React.createElement(ChatList, { className: 'chat-list', dataSource: chats }))
+  </script>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>`
+
+export default function register(app: Hono<{ Bindings: Env }>) {
+  app.get('/chatpage', c => c.html(HTML))
+}


### PR DESCRIPTION
## Summary
- fix `/chatpage` to render a sample ChatList without Babel
- document the chat list

## Testing
- `npm install`
- `npx tsc`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841b1bc3cdc8332874c1d2c8150dac8