### PR TITLE
Add dynamic chat route

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,7 @@ For a guided setup experience, visit `/wizard`. This multi-step form walks throu
 
 Navigate to `/chat` for a Telegram-style interface powered by **react-chat-elements**. Enter a group ID and sender name, type your message and optionally pick a time. Messages appear in a scrolling chat window and can be scheduled in bulk with **Schedule All** which posts them to `/advanced`.
 
+You can also open `/chat/<groupId>` to jump straight into a specific group. This page pre-fills the group ID from the URL and lets you send messages in a Telegram-like view.
+
 Visit `/chatpage` for a multi-group view rendered with **ChatList** from **react-chat-elements**. The page lists a few sample chats similar to Telegram.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { Env } from './types'
 import registerRoot from './routes/root'
 import registerWizard from './routes/wizard'
 import registerChat from './routes/chat'
+import registerChatId from './routes/chat_id'
 import registerChatPage from './routes/chatpage'
 import registerSchedule from './routes/schedule'
 import registerAdvanced from './routes/advanced'
@@ -15,6 +16,7 @@ const app = new Hono<{ Bindings: Env }>()
 registerRoot(app)
 registerWizard(app)
 registerChat(app)
+registerChatId(app)
 registerChatPage(app)
 registerSchedule(app)
 registerAdvanced(app)

--- a/src/routes/chat_id.ts
+++ b/src/routes/chat_id.ts
@@ -1,0 +1,81 @@
+import { Hono } from 'hono'
+import type { Env } from '../types'
+
+function page(id: string) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Chat ${id}</title>
+  <link rel="stylesheet" href="https://unpkg.com/react-chat-elements/dist/main.css" />
+  <script type="module">
+    import React from 'https://esm.sh/react@18.2.0'
+    import ReactDOM from 'https://esm.sh/react-dom@18.2.0'
+    import { MessageList, Input } from 'https://esm.sh/react-chat-elements@12.0.18'
+    window.React = React
+    window.ReactDOM = ReactDOM
+    window.ReactChatElements = { MessageList, Input }
+  </script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; }
+    .chat-window { border: 1px solid #ccc; height: 400px; overflow-y: scroll; padding: 10px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const GROUP_ID = "${id}"
+    const { MessageList, Input } = window.ReactChatElements
+
+    function App() {
+      const [sender, setSender] = React.useState('user')
+      const [text, setText] = React.useState('')
+      const [time, setTime] = React.useState('')
+      const [messages, setMessages] = React.useState([])
+
+      const addMessage = () => {
+        const ts = time ? new Date(time).toISOString() : new Date().toISOString()
+        const m = { sender_id: sender, message_content: text, send_at: ts }
+        setMessages(prev => [...prev, m])
+        setText('')
+        setTime('')
+        fetch('/log', { method: 'POST', body: new URLSearchParams({ group_id: GROUP_ID, sender_id: sender, message_content: m.message_content, send_at: ts }) })
+      }
+
+      const scheduleAll = () => {
+        const payload = { groups: [ { group_id: GROUP_ID, conversations: [ { messages } ] } ] }
+        fetch('/advanced', { method: 'POST', body: new URLSearchParams({ payload: JSON.stringify(payload) }) })
+          .then(r => r.json())
+          .then(r => alert('Scheduled ' + (r.ids ? r.ids.length : 0) + ' messages'))
+      }
+
+      const dataSource = messages.map(m => ({ position: m.sender_id === 'user' ? 'right' : 'left', type: 'text', text: m.message_content, date: new Date(m.send_at) }))
+
+      return (
+        <div>
+          <h1>Group {GROUP_ID}</h1>
+          <div className="chat-window">
+            <MessageList className="message-list" lockable={true} toBottomHeight={'100%'} dataSource={dataSource} />
+          </div>
+          <Input placeholder="Message" multiline={true} value={text} onChange={e => setText(e.target.value)} rightButtons={null} />
+          <input type="datetime-local" value={time} onChange={e => setTime(e.target.value)} />
+          <input placeholder="Sender" value={sender} onChange={e => setSender(e.target.value)} />
+          <button onClick={addMessage}>Add</button>
+          <button onClick={scheduleAll}>Schedule All</button>
+        </div>
+      )
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'))
+  </script>
+</body>
+</html>`
+}
+
+export default function register(app: Hono<{ Bindings: Env }>) {
+  app.get('/chat/:id', c => {
+    const id = c.req.param('id')
+    return c.html(page(id))
+  })
+}


### PR DESCRIPTION
## Summary
- support `/chat/:id` route for group-specific chat view
- document the new route in README

## Testing
- `npm install`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_6841defa731c83328745939d7ca23b77