### PR TITLE
Add reply UI to chat pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ For a guided setup experience, visit `/wizard`. This multi-step form walks throu
 
 Navigate to `/chat` for a Telegram-style interface powered by **react-chat-elements**. Enter a group ID and sender name, type your message and optionally pick a time. Messages appear in a scrolling chat window and can be scheduled in bulk with **Schedule All** which posts them to `/advanced`.
 
+You can click the reply arrow on any message to quote it in the composer. The selected message appears above the input field and the relation is stored when scheduling.
+
 You can also open `/chat/<groupId>` to jump straight into a specific group. This page pre-fills the group ID from the URL and lets you send messages in a Telegram-like view. The worker serves this path directly, so visiting `/chat/mygroup` uses the segment after `/chat/` as the group ID.
 
 

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -20,6 +20,7 @@ const HTML = `<!DOCTYPE html>
   <style>
     body { font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; }
     .chat-window { border: 1px solid #ccc; height: 400px; overflow-y: scroll; padding: 10px; }
+    .reply-preview { background: #f0f0f0; padding: 4px; margin-top: 4px; font-size: 0.9em; }
   </style>
 </head>
 <body>
@@ -33,14 +34,18 @@ const HTML = `<!DOCTYPE html>
       const [text, setText] = React.useState('');
       const [time, setTime] = React.useState('');
       const [messages, setMessages] = React.useState([]);
+      const [replyTo, setReplyTo] = React.useState(null);
 
       const addMessage = () => {
         const ts = time ? new Date(time).toISOString() : new Date().toISOString();
-        const m = { sender_id: sender, message_content: text, send_at: ts };
+        const m = { sender_id: sender, message_content: text, send_at: ts, reply_to: replyTo };
         setMessages(prev => [...prev, m]);
         setText('');
         setTime('');
-        fetch('/log', { method: 'POST', body: new URLSearchParams({ group_id: groupId, sender_id: sender, message_content: m.message_content, send_at: ts }) });
+        setReplyTo(null);
+        const params = new URLSearchParams({ group_id: groupId, sender_id: sender, message_content: m.message_content, send_at: ts });
+        if (replyTo !== null) params.append('reply_to', replyTo.toString());
+        fetch('/log', { method: 'POST', body: params });
       };
 
       const scheduleAll = () => {
@@ -50,7 +55,13 @@ const HTML = `<!DOCTYPE html>
           .then(r => alert('Scheduled ' + (r.ids ? r.ids.length : 0) + ' messages'));
       };
 
-      const dataSource = messages.map(m => ({ position: m.sender_id === 'user' ? 'right' : 'left', type: 'text', text: m.message_content, date: new Date(m.send_at) }));
+      const dataSource = messages.map((m, idx) => {
+        const msg: any = { position: m.sender_id === 'user' ? 'right' : 'left', type: 'text', text: m.message_content, date: new Date(m.send_at), replyButton: true };
+        if (typeof m.reply_to === 'number' && messages[m.reply_to]) {
+          msg.reply = { title: messages[m.reply_to].sender_id, message: messages[m.reply_to].message_content };
+        }
+        return msg;
+      });
 
       return (
         <div>
@@ -60,8 +71,20 @@ const HTML = `<!DOCTYPE html>
             <input placeholder="Sender" value={sender} onChange={e => setSender(e.target.value)} />
           </div>
           <div className="chat-window">
-            <MessageList className="message-list" lockable={true} toBottomHeight={'100%'} dataSource={dataSource} />
+            <MessageList
+              className="message-list"
+              lockable={true}
+              toBottomHeight={'100%'}
+              dataSource={dataSource}
+              onReplyMessageClick={(_, index) => setReplyTo(index)}
+            />
           </div>
+          {replyTo !== null && (
+            <div className="reply-preview">
+              Replying to {messages[replyTo]?.sender_id}: "{messages[replyTo]?.message_content}"
+              <button onClick={() => setReplyTo(null)}>Cancel</button>
+            </div>
+          )}
           <Input placeholder="Message" multiline={true} value={text} onChange={e => setText(e.target.value)} rightButtons={null} />
           <input type="datetime-local" value={time} onChange={e => setTime(e.target.value)} />
           <button onClick={addMessage}>Add</button>

--- a/src/routes/chat_id.ts
+++ b/src/routes/chat_id.ts
@@ -20,6 +20,7 @@ function page(id: string) {
   <style>
     body { font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; }
     .chat-window { border: 1px solid #ccc; height: 400px; overflow-y: scroll; padding: 10px; }
+    .reply-preview { background: #f0f0f0; padding: 4px; margin-top: 4px; font-size: 0.9em; }
   </style>
 </head>
 <body>
@@ -33,14 +34,18 @@ function page(id: string) {
       const [text, setText] = React.useState('')
       const [time, setTime] = React.useState('')
       const [messages, setMessages] = React.useState([])
+      const [replyTo, setReplyTo] = React.useState(null)
 
       const addMessage = () => {
         const ts = time ? new Date(time).toISOString() : new Date().toISOString()
-        const m = { sender_id: sender, message_content: text, send_at: ts }
+        const m = { sender_id: sender, message_content: text, send_at: ts, reply_to: replyTo }
         setMessages(prev => [...prev, m])
         setText('')
         setTime('')
-        fetch('/log', { method: 'POST', body: new URLSearchParams({ group_id: GROUP_ID, sender_id: sender, message_content: m.message_content, send_at: ts }) })
+        setReplyTo(null)
+        const params = new URLSearchParams({ group_id: GROUP_ID, sender_id: sender, message_content: m.message_content, send_at: ts })
+        if (replyTo !== null) params.append('reply_to', replyTo.toString())
+        fetch('/log', { method: 'POST', body: params })
       }
 
       const scheduleAll = () => {
@@ -50,14 +55,32 @@ function page(id: string) {
           .then(r => alert('Scheduled ' + (r.ids ? r.ids.length : 0) + ' messages'))
       }
 
-      const dataSource = messages.map(m => ({ position: m.sender_id === 'user' ? 'right' : 'left', type: 'text', text: m.message_content, date: new Date(m.send_at) }))
+      const dataSource = messages.map((m, idx) => {
+        const item: any = { position: m.sender_id === 'user' ? 'right' : 'left', type: 'text', text: m.message_content, date: new Date(m.send_at), replyButton: true }
+        if (typeof m.reply_to === 'number' && messages[m.reply_to]) {
+          item.reply = { title: messages[m.reply_to].sender_id, message: messages[m.reply_to].message_content }
+        }
+        return item
+      })
 
       return (
         <div>
           <h1>Group {GROUP_ID}</h1>
           <div className="chat-window">
-            <MessageList className="message-list" lockable={true} toBottomHeight={'100%'} dataSource={dataSource} />
+            <MessageList
+              className="message-list"
+              lockable={true}
+              toBottomHeight={'100%'}
+              dataSource={dataSource}
+              onReplyMessageClick={(_, index) => setReplyTo(index)}
+            />
           </div>
+          {replyTo !== null && (
+            <div className="reply-preview">
+              Replying to {messages[replyTo]?.sender_id}: "{messages[replyTo]?.message_content}"
+              <button onClick={() => setReplyTo(null)}>Cancel</button>
+            </div>
+          )}
           <Input placeholder="Message" multiline={true} value={text} onChange={e => setText(e.target.value)} rightButtons={null} />
           <input type="datetime-local" value={time} onChange={e => setTime(e.target.value)} />
           <input placeholder="Sender" value={sender} onChange={e => setSender(e.target.value)} />


### PR DESCRIPTION
## Summary
- enhance `/chat` and `/chat/:id` interfaces with reply preview and buttons
- update README with instructions on replying to messages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841ea91830c8332a3ec3fca8818fb30